### PR TITLE
Add --throttle option

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Options:
                           surrounded with quotes when command contains spaces
   -d, --debounce          Debounce timeout in ms for executing command
                                                                   [default: 400]
+  -t, --throttle          Throttle timeout in ms for executing command
+                                                                  [default: 0]
   -s, --follow-symlinks   When not set, only the symlinks themselves will be
                           watched for changes instead of following the link
                           references and bubbling events through the links path

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ var EVENT_DESCRIPTIONS = {
 
 var defaultOpts = {
     debounce: 400,
+    throttle: 0,
     followSymlinks: false,
     ignore: null,
     polling: false,
@@ -53,6 +54,12 @@ var argv = require('yargs')
         alias: 'debounce',
         default: defaultOpts.debounce,
         describe: 'Debounce timeout in ms for executing command',
+        type: 'number'
+    })
+    .option('t', {
+        alias: 'throttle',
+        default: defaultOpts.throttle,
+        describe: 'Throttle timeout in ms for executing command',
         type: 'number'
     })
     .option('s', {
@@ -131,7 +138,8 @@ function startWatching(opts) {
     var chokidarOpts = createChokidarOpts(opts);
     var watcher = chokidar.watch(opts.patterns, chokidarOpts);
 
-    var debouncedRun = _.debounce(run, opts.debounce);
+    var throttledRun = _.throttle(run, opts.throttle);
+    var debouncedRun = _.debounce(throttledRun, opts.debounce);
     watcher.on('all', function(event, path) {
         var description = EVENT_DESCRIPTIONS[event] + ':';
 


### PR DESCRIPTION
Adds a `--throttle` option to the CLI as a quick-and-dirty fix for commands being fired before previous commands have finished executing. Resolves kimmobrunfeldt/chokidar-cli#13