### PR TITLE
Trying something to fix the mingw issue.

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -7,7 +7,7 @@ var shellQuote = require('shell-quote');
 // We assume that Windows provides COMSPEC env variable
 // and other platforms provide SHELL env variable
 var SHELL_PATH = process.env.SHELL || process.env.COMSPEC;
-var EXECUTE_OPTION = process.env.COMSPEC !== undefined ? '/c' : '-c';
+var EXECUTE_OPTION = process.env.COMSPEC !== undefined && process.env.SHELL === undefined ? '/c' : '-c';
 
 // XXX: Wrapping tos to a promise is a bit wrong abstraction. Maybe RX suits
 // better?


### PR DESCRIPTION
Hi again, this simplistic fix works for me.

We only need to test the presence of *both* `COMSPEC` and `SHELL`.

Tested on Mac OS X (bash, no `COMSPEC`, yes `SHELL`), Mingw on Windows 8 (bash, yes `COMSPEC`, yes `SHELL`) and Cmd.exe on Windows 8 (cmd, yes `COMSPEC`, no `SHELL`).