### PR TITLE
Path and event variable replacement in custom command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ test/b.js
 
 ```chokidar '**/*.less' -c 'npm run build-less' --polling```
 
+**Pass the path and event details in to your custom command
+
+```chokidar '**/*.less' -c 'if [ "{event}" = "change" ]; then npm run build-less -- {path}; fi;'```
 
 **Detailed help**
 
@@ -80,7 +83,10 @@ Guide to globs: https://github.com/isaacs/node-glob#glob-primer
 
 Options:
   -c, --command           Command to run after each change. Needs to be
-                          surrounded with quotes when command contains spaces
+                          surrounded with quotes when command contains spaces.
+                          Instances of `{path}` or `{event}` within the command
+                          will be replaced by the corresponding values from the
+                          chokidar event.
   -d, --debounce          Debounce timeout in ms for executing command
                                                                   [default: 400]
   -t, --throttle          Throttle timeout in ms for executing command

--- a/index.js
+++ b/index.js
@@ -48,7 +48,9 @@ var argv = require('yargs')
         alias: 'command',
         describe: 'Command to run after each change. ' +
                   'Needs to be surrounded with quotes when command contains ' +
-                  'spaces'
+                  'spaces. Instances of `{path}` or `{event}` within the ' +
+                  'command will be replaced by the corresponding values from ' +
+                  'the chokidar event.'
     })
     .option('d', {
         alias: 'debounce',

--- a/index.js
+++ b/index.js
@@ -153,7 +153,11 @@ function startWatching(opts) {
 
         // TODO: commands might be still run concurrently
         if (opts.command) {
-            debouncedRun(opts.command);
+            debouncedRun(
+                opts.command
+                    .replace(/\{path\}/ig, path)
+                    .replace(/\{event\}/ig, event)
+            );
         }
     });
 

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -16,7 +16,7 @@ var CHANGE_FILE = 'dir/change';
 
 // Time to wait for different tasks
 var TIMEOUT_WATCH_READY = 1000;
-var TIMEOUT_CHANGE_DETECTED = 500;
+var TIMEOUT_CHANGE_DETECTED = 700;
 
 // Abs path to test directory
 var testDir = path.resolve(__dirname);

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -17,6 +17,7 @@ var CHANGE_FILE = 'dir/change';
 // Time to wait for different tasks
 var TIMEOUT_WATCH_READY = 1000;
 var TIMEOUT_CHANGE_DETECTED = 700;
+var TIMEOUT_KILL = TIMEOUT_WATCH_READY + TIMEOUT_CHANGE_DETECTED + 1000;
 
 // Abs path to test directory
 var testDir = path.resolve(__dirname);
@@ -73,7 +74,7 @@ describe('chokidar-cli', function() {
                     // Kill child after test case
                     child.kill();
                     killed = true;
-                }, TIMEOUT_WATCH_READY + TIMEOUT_CHANGE_DETECTED + 1000);
+                }, TIMEOUT_KILL);
             }
         })
         .then(function childProcessExited(exitCode) {
@@ -90,6 +91,27 @@ describe('chokidar-cli', function() {
                 assert(changeFileExists(), 'change file should exist')
             }, TIMEOUT_CHANGE_DETECTED)
         }, TIMEOUT_WATCH_READY);
+    });
+
+    it('should replace {path} and {event} in command', function(done) {
+        var command = "echo '{event}:{path}' > " + CHANGE_FILE;
+
+        setTimeout(function() {
+          fs.writeFileSync(resolve('dir/a.js'), 'content');
+        }, TIMEOUT_WATCH_READY);
+
+        run('node ../index.js "dir/a.js" -c "' + command + '"', {
+            pipe: DEBUG_TESTS,
+            cwd: './test',
+            callback: function(child) {
+                setTimeout(child.kill.bind(child), TIMEOUT_KILL);
+            }
+        })
+        .then(function() {
+            var res = fs.readFileSync(resolve(CHANGE_FILE)).toString().trim();
+            assert.equal(res, 'change:dir/a.js', 'need event/path detail');
+            done()
+        });
     });
 });
 


### PR DESCRIPTION
Resolves #11

Used `{path}` as the replacement string instead of mimicking env var syntax like `$path`, because the latter did not work for me using zsh. Open to changing the format to anything else that works if there are any preferences to do it differently.