### PR TITLE
Run one process for command by default, add `--concurrent` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,23 +150,17 @@ function startWatching(opts) {
     var watcher = chokidar.watch(opts.patterns, chokidarOpts);
     var child;
 
-    // var throttledRun = _.throttle(run, opts.throttle);
-    // var debouncedRun = _.debounce(throttledRun, opts.debounce);
     watcher.on('all', function(event, path) {
         var description = EVENT_DESCRIPTIONS[event] + ':';
         function executeCommand() {
-            if (child) child.removeAllListeners();
-            child = run(
-                opts.command
-                    .replace(/\{path\}/ig, path)
-                    .replace(/\{event\}/ig, event)
-            );
-            child.once('error', function(error) {
-                throw error;
-            });
-            child.once('exit', function() {
-                child = undefined;
-            });
+            console.log('will run command');
+            _.debounce(_.throttle(function() {
+                if (child) child.removeAllListeners();
+                console.log('spawning new command process');
+                child = childProcess.spawn(SHELL_PATH, [EXECUTE_OPTION, opts.command.replace(/\{path\}/ig, path).replace(/\{event\}/ig, event)]);
+                child.once('error', function(error) { throw error; });
+                child.once('exit', function() { child = undefined; });
+            }, opts.throttle), opts.debounce)();
         }
 
         if (opts.verbose) {
@@ -181,10 +175,13 @@ function startWatching(opts) {
             // If a previous run of command created a child, and the concurrent option is not set,
             // then we should kill that child process before running it again
             if (child && !opts.concurrent) {
+                console.log('run command after killing previous child');
                 child.once('exit', executeCommand);
                 child.kill();
+            } else {
+                console.log('run command');
+                setImmediate(executeCommand);
             }
-            setImmediate(executeCommand);
         }
     });
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var childProcess = require('child_process');
 var Promise = require('bluebird');
 var _ = require('lodash');
 var chokidar = require('chokidar');
-var utils = require('./utils');
 
 var EVENT_DESCRIPTIONS = {
     add: 'File added',
@@ -13,6 +12,12 @@ var EVENT_DESCRIPTIONS = {
     unlinkDir: 'Directory removed',
     change: 'File changed'
 };
+
+// Try to resolve path to shell.
+// We assume that Windows provides COMSPEC env variable
+// and other platforms provide SHELL env variable
+var SHELL_PATH = process.env.SHELL || process.env.COMSPEC;
+var EXECUTE_OPTION = process.env.COMSPEC !== undefined && process.env.SHELL === undefined ? '/c' : '-c';
 
 var defaultOpts = {
     debounce: 400,
@@ -25,7 +30,8 @@ var defaultOpts = {
     verbose: false,
     silent: false,
     initial: false,
-    command: null
+    command: null,
+    concurrent: false
 };
 
 var VERSION = 'chokidar-cli: ' + require('./package.json').version +
@@ -83,6 +89,11 @@ var argv = require('yargs')
         default: defaultOpts.initial,
         type: 'boolean'
     })
+    .option('concurrent', {
+        describe: 'When set, command is not killed before invoking again',
+        default: defaultOpts.concurrent,
+        type: 'boolean'
+    })
     .option('p', {
         alias: 'polling',
         describe: 'Whether to use fs.watchFile(backed by polling) instead of ' +
@@ -134,15 +145,29 @@ function getUserOpts(argv) {
     return argv;
 }
 
-// Estimates spent working hours based on commit dates
 function startWatching(opts) {
     var chokidarOpts = createChokidarOpts(opts);
     var watcher = chokidar.watch(opts.patterns, chokidarOpts);
+    var child;
 
-    var throttledRun = _.throttle(run, opts.throttle);
-    var debouncedRun = _.debounce(throttledRun, opts.debounce);
+    // var throttledRun = _.throttle(run, opts.throttle);
+    // var debouncedRun = _.debounce(throttledRun, opts.debounce);
     watcher.on('all', function(event, path) {
         var description = EVENT_DESCRIPTIONS[event] + ':';
+        function executeCommand() {
+            if (child) child.removeAllListeners();
+            child = run(
+                opts.command
+                    .replace(/\{path\}/ig, path)
+                    .replace(/\{event\}/ig, event)
+            );
+            child.once('error', function(error) {
+                throw error;
+            });
+            child.once('exit', function() {
+                child = undefined;
+            });
+        }
 
         if (opts.verbose) {
             console.error(description, path);
@@ -152,13 +177,14 @@ function startWatching(opts) {
             }
         }
 
-        // XXX: commands might be still run concurrently
         if (opts.command) {
-            debouncedRun(
-                opts.command
-                    .replace(/\{path\}/ig, path)
-                    .replace(/\{event\}/ig, event)
-            );
+            // If a previous run of command created a child, and the concurrent option is not set,
+            // then we should kill that child process before running it again
+            if (child && !opts.concurrent) {
+                child.once('exit', executeCommand);
+                child.kill();
+            }
+            setImmediate(executeCommand);
         }
     });
 
@@ -212,11 +238,7 @@ function _resolveIgnoreOpt(ignoreOpt) {
 }
 
 function run(cmd) {
-    return utils.run(cmd)
-    .catch(function(err) {
-        console.error('Error when executing', cmd);
-        console.error(err.stack);
-    });
+    return childProcess.spawn(SHELL_PATH, [EXECUTE_OPTION, cmd]);
 }
 
 main();

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -36,7 +36,7 @@ describe('chokidar-cli', function() {
         .then(function() {
             done();
         });
-    })
+    });
 
     it('help should be succesful', function(done) {
         run('node index.js --help', {pipe: DEBUG_TESTS})
@@ -88,8 +88,8 @@ describe('chokidar-cli', function() {
             fs.writeFileSync(resolve('dir/subdir/c.less'), 'content');
 
             setTimeout(function() {
-                assert(changeFileExists(), 'change file should exist')
-            }, TIMEOUT_CHANGE_DETECTED)
+                assert(changeFileExists(), 'change file should exist');
+            }, TIMEOUT_CHANGE_DETECTED);
         }, TIMEOUT_WATCH_READY);
     });
 
@@ -110,7 +110,7 @@ describe('chokidar-cli', function() {
         .then(function() {
             var res = fs.readFileSync(resolve(CHANGE_FILE)).toString().trim();
             assert.equal(res, 'change:dir/a.js', 'need event/path detail');
-            done()
+            done();
         });
     });
 });


### PR DESCRIPTION
addresses #20 

adds a new boolean option `--concurrent` which, when true, behaves the same as the tool behaves today. when it is false (the default), it means the previous process launched for the command is killed before a new process is created again. i think this is a more sane default, because its more likely what users already expect. its more dangerous when the option is set to true because commands that recompile files might clobber the same file system state, or in my case, relaunching a server process will fail because the port will already be used.

i'm looking for feedback on this implementation, as i don't think its ready to merge yet. here is what i think is left before this can be merged:
- [ ] does the default value of false make sense? would that be considered "breaking"?
- [ ] okay to not use `utils` implementation of `run()`? i needed a different abstraction (as the existing `run()` implementation notes, a Promise is probably the wrong abstraction) which provided a reference to the child process, so that it could later be killed.
- [ ] need to implement tests for the new feature, but i don't have a means of getting the child process of the child process that the `run()` helper launches. might need to completely rethink the design of that helper (and its not even being reused so it can probably just live in the `test/` directory).
- [ ] the code is naive and could probably be cleaned up. scopes/closure are probably leaned on too much. any suggestions?

i also added tests for the `--throttle` and `--debounce` options.