### PR TITLE
Add concurrency models

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,10 +31,12 @@
   "license": "MIT",
   "dependencies": {
     "anymatch": "^1.1.0",
-    "bluebird": "^2.9.24",
+    "async": "^2.0.0-rc.1",
+    "bluebird": "^3.3.4",
     "chokidar": "^1.0.1",
+    "colors": "^1.1.2",
+    "exec-sh": "^0.2.0",
     "lodash": "^3.7.0",
-    "shell-quote": "^1.4.3",
     "yargs": "^3.7.2"
   },
   "devDependencies": {

--- a/utils.js
+++ b/utils.js
@@ -1,63 +1,95 @@
-var childProcess = require('child_process');
-var _ = require('lodash');
 var Promise = require('bluebird');
-var shellQuote = require('shell-quote');
+var execSh = require('exec-sh');
+var colors = require('colors');
+var async = require('async');
+var _ = require('lodash');
+var colors = require('colors');
 
-// Try to resolve path to shell.
-// We assume that Windows provides COMSPEC env variable
-// and other platforms provide SHELL env variable
-var SHELL_PATH = process.env.SHELL || process.env.COMSPEC;
-var EXECUTE_OPTION = process.env.COMSPEC !== undefined && process.env.SHELL === undefined ? '/c' : '-c';
+// Allow to cancel bluebird promises
+Promise.config({
+    cancellation: true
+});
 
-// XXX: Wrapping tos to a promise is a bit wrong abstraction. Maybe RX suits
-// better?
-function run(cmd, opts) {
-    if (!SHELL_PATH) {
-        // If we cannot resolve shell, better to just crash
-        throw new Error('$SHELL environment variable is not set.');
-    }
+// Execute command as cancellable promise
+function exec(task, finish) {
+    task.promise = new Promise(function(resolve, reject, onCancel) {
+        var process = execSh(task.cmd, {}, function(err, stdout, stderr) {
+            // Avoid issues with killing exited process
+            process = undefined;
 
-    opts = _.merge({
-        pipe: true,
-        cwd: undefined,
-        callback: function(child) {
-            // Since we return promise, we need to provide
-            // this callback if one wants to access the child
-            // process reference
-            // Called immediately after successful child process
-            // spawn
-        }
-    }, opts);
+            // No need to reject/resolve if promise was cancelled and process was killed
+            if (task.promise.isCancelled()) {
+                return;
+            }
 
-    return new Promise(function(resolve, reject) {
-        var child;
+            if (err) {
+                // Error code !== 0
+                console.log(('Error code: ' + err.code + ' for run #' + task.number).red);
+                reject(err, stdout, stderr);
+            }
+            else {
+                console.log(('Finished run #' + task.number).green);
+                resolve();
+            }
+        });
 
-        try {
-            child = childProcess.spawn(SHELL_PATH, [EXECUTE_OPTION, cmd], {
-                cwd: opts.cwd,
-                stdio: opts.pipe ? 'inherit' : null
-            });
-        } catch (e) {
-            return Promise.reject(e);
-        }
+        onCancel(function () {
+            console.log(('Cancelled run #' + task.number).yellow);
+            if (process) {
+                console.log(('Killing run #' + task.number).yellow);
 
-        opts.callback(child);
+                // XXX: should we send SIGKILL or account for sub-processes somehow
+                // or is it really as simple as this
+                process.kill();
+            }
+        });
+    });
 
-        function errorHandler(err) {
-            child.removeListener('close', closeHandler);
-            reject(err);
-        }
-
-        function closeHandler(exitCode) {
-            child.removeListener('error', errorHandler);
-            resolve(exitCode);
-        }
-
-        child.once('error', errorHandler);
-        child.once('close', closeHandler);
+    task.promise.finally(function () {
+        // Tell the queue that we're finished
+        finish();
     });
 }
 
+// Create runner based on specified concurrency model
+function runner(concurrencyModel) {
+    // async.queue does not support unlimited concurrent tasks.
+    // Set sane (?) default - 100 tasks for parallel mode
+    var concurrency = ('parallel' === concurrencyModel) ? 100 : 1;
+
+    // Create worker queue
+    var queue = async.queue(exec, concurrency);
+    var taskNumber = 1;
+
+    var run = function (cmd) {
+        // In queue mode: we don't want to queue more than one
+        // extra task to be run after filesystem stops changing
+        if ('queue' === concurrencyModel && queue.length()) {
+            console.log(('Command is already queued, skipping').blue);
+
+            return;
+        }
+
+        // In kill mode: cancel running task before pushing new one
+        if ('kill' === concurrencyModel && queue.running()) {
+            _.each(queue.workersList(), function (worker) {
+                worker.data.promise.cancel();
+            });
+        }
+
+        console.log(('Adding task #' + taskNumber + ' to the queue').inverse);
+        queue.push({
+            cmd: cmd,
+            number: taskNumber++
+        });
+    };
+
+    // Return new runner with run method
+    return {
+        run: run
+    };
+}
+
 module.exports = {
-    run: run
+    runner: runner
 };


### PR DESCRIPTION
Here is my take on concurrency based on [async.queue](https://github.com/caolan/async#queue) and bluedird's [cancellable promises](http://bluebirdjs.com/docs/api/cancellation.html). It represents shell commands as promises, which when cancelled would kill the underlying process. It also puts commands into the queue to allow fine-grained control over concurrency models.

I've also utilized [exec-sh](https://www.npmjs.com/package/exec-sh) which abstracts away cross platform command execution and stdio stream forwarding.

This PR adds `--concurrency` option with three possible concurrency model choices:
- `kill` (default): kills unfinished process before starting a new one. **Example use case:** assets compilation. For example if *.sass file changes you want to kill current build process and start a new one.
- `queue`: waits until previously started process is finished before starting a new one. **Example use case:** continuous rsync on file changes. If file changes during syncing you probably want to let rsync finish and run it once more after it's done.
- `parallel`: executes subsequent commands in parallel. I believe this option is how chokidar-cli works currently.

Note that this PR needs some clean up before it is ready to merge.