### PR TITLE
turn off debounce/throttle with a negative wait time

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,8 +139,8 @@ function startWatching(opts) {
     var chokidarOpts = createChokidarOpts(opts);
     var watcher = chokidar.watch(opts.patterns, chokidarOpts);
 
-    var throttledRun = _.throttle(run, opts.throttle);
-    var debouncedRun = _.debounce(throttledRun, opts.debounce);
+    var throttledRun = opts.throttle >= 0 ? _.throttle(run, opts.throttle) : run;
+    var debouncedRun = opts.debounce >= 0 ? _.debounce(throttledRun, opts.debounce) : throttledRun;
     watcher.on('all', function(event, path) {
         var description = EVENT_DESCRIPTIONS[event] + ':';
 


### PR DESCRIPTION
Not sure if this is the best way to do this, but it seemed like the least impact on the existing configuration.

Only weird thing is negative numbers have to be specified explicitly like `--t=-1`, as `yargs` parses `-t -1` to mean `true` otherwise.
