### PR TITLE
Added additional command string replacement tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test-fixtures
 coverage
 *.bak
 *.log
+.idea

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var Promise = require('bluebird');
 var _ = require('lodash');
 var chokidar = require('chokidar');
 var utils = require('./utils');
+var pathParse = require('path-parse');
 
 var EVENT_DESCRIPTIONS = {
     add: 'File added',
@@ -154,9 +155,15 @@ function startWatching(opts) {
 
         // XXX: commands might be still run concurrently
         if (opts.command) {
+            var parsedPath = pathParse(path);
             debouncedRun(
                 opts.command
                     .replace(/\{path\}/ig, path)
+                    .replace(/\{root\}/ig, parsedPath.root)
+                    .replace(/\{dir\}/ig, parsedPath.dir)
+                    .replace(/\{base\}/ig, parsedPath.base)
+                    .replace(/\{ext\}/ig, parsedPath.ext)
+                    .replace(/\{name\}/ig, parsedPath.name)
                     .replace(/\{event\}/ig, event)
             );
         }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "bluebird": "^2.9.24",
     "chokidar": "^1.4.3",
     "lodash": "^3.7.0",
+    "path-parse": "^1.0.5",
     "shell-quote": "^1.4.3",
     "yargs": "^3.7.2"
   },


### PR DESCRIPTION
Added command replacement tokens {root}, {dir}, {base}, {ext} and {name} to allow for more flexiblity in specifiying commands.

Unfortunately, your tests do not seem to work under Windows so I wasn't able to extend the replacement test. (killing a child process kills cmd.exe but not the grand-child process spawned by cmd.exe, windows does not have a touch command, etc)