### PR TITLE
Use resolve for consistency.

### DIFF
--- a/test/test-all.js
+++ b/test/test-all.js
@@ -21,7 +21,7 @@ var TIMEOUT_KILL = TIMEOUT_WATCH_READY + TIMEOUT_CHANGE_DETECTED + 1000;
 
 // Abs path to test directory
 var testDir = path.resolve(__dirname);
-process.chdir(path.join(testDir, '..'));
+process.chdir(resolve('..'));
 
 describe('chokidar-cli', function() {
     this.timeout(5000);


### PR DESCRIPTION
Use resolve in all cases of path.join in the test/test-all.js for consistency.