### PR TITLE
Explain what devs need to do to maximise platform compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,21 @@ npm install -g chokidar-cli
 
 ## Usage
 
+Chokidar can be invoked using the `chokidar` command, without the `-cli` suffix.
+
+Arguments use the form of runtime flags with string parameters, delimited by quotes. While in principal both single and double quotes are supported by `chokidar-cli`, the actual command line argument parsing is dependent on the operating system and shell used; for cross-platform compatibility, use double quotes (with escaping, if necessary), as single quotes are not universally supported by all operating systems.
+
+This is particularly important when using chokidar-cli for run scripts specified in `package.json`. For maximum platform compatibility, make sure to use escaped double quotes around chokidar's parameters:
+
+```
+"run": {
+  "chokidar": "chokidar \"**/*.js\" -c \"...\"",
+  ...
+},
+```
+
+## Default behavior
+
 By default `chokidar` streams changes for all patterns to stdout:
 
 ```bash


### PR DESCRIPTION
Given that the description for chokidar-cli is a "fast cross-platform cli utility", the docs needs updating so that it tells people _not_ to use single quotes.

Single quotes for cli arguments are not universally supported, whereas double quotes are. As such, while it might be "ugly", in order to make chokidar/chokidar-cli to actually work across the board, devs _must_ use double quotes. Failure to do so means that as pretty as a run script might look, it guaranteed won't work on Windows, and might not work in custom shells that follow the same rules about single vs. double quotes.

I didn't update the rest of the readme to use double quotes, although I would strongly recommend a follow-up to do so anyway. It might no longer look quite as pretty, but pretty is useless if it doesn't work, and updating the entire README.md to use (escaped) double quotes means example snippets can be copy-pasted by everyone, rather than only about half the dev population =)