### PR TITLE
Update lodash version to resolve npm audit vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1285,9 +1285,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.12",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.12.tgz",
+      "integrity": "sha512-+CiwtLnsJhX03p20mwXuvhoebatoh5B3tt+VvYlrPgZC1g36y+RRbkufX95Xa+X4I59aWEacDFYwnJZiyBh9gA=="
     },
     "map-age-cleaner": {
       "version": "0.1.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "bluebird": "3.5.3",
     "chokidar": "2.1.1",
-    "lodash": "4.17.11",
+    "lodash": "4.17.12",
     "yargs": "12.0.5"
   },
   "devDependencies": {


### PR DESCRIPTION
- Update `lodash` version to resolve npm audit issue https://nodesecurity.io/advisories/1065
