### PR TITLE
Update Travis PR check Node.js versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-- '4'
-- '6'
 - '8'
 - '9'
 - '10'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - '8'
 - '9'
 - '10'
+- '12'
 notifications:
   email:
   - kimmobrunfeldt+chokidar@gmail.com


### PR DESCRIPTION
[According to Wikipedia](https://en.wikipedia.org/wiki/Node.js#Releases), Node.js 4 and 6 have reached end-of-life. This project _probably_ shouldn't test PRs on these unsupported versions.

Also! Node.js 12 is out. This project _probably_ should test PRs on it!