### PR TITLE
Remove .npmignore.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-.jshintrc
-.nvmrc
-.travis.yml
-CONTRIBUTING.md
-test/


### PR DESCRIPTION
We now specify the files to include in package.json files property.