### PR TITLE
Switch to GitHub Actions CI.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: Tests
+on: [push, pull_request]
+env:
+  CI: true
+
+jobs:
+  run:
+    name: Node ${{ matrix.node }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # change `8.16.1` to `8` when https://github.com/actions/setup-node/issues/27 is fixed
+        node: [8.16.1, 10, 12]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v1
+
+      - name: Set Node.js version
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
+
+      - run: node --version
+      - run: npm --version
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,6 @@ jobs:
 
       - name: Run tests
         run: npm test
+        shell: bash
         env:
           SHELL: "/bin/bash"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,5 @@ jobs:
 
       - name: Run tests
         run: npm test
+        env:
+          SHELL: "/bin/bash"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: node_js
-node_js:
-  - "8"
-  - "10"
-  - "12"
-notifications:
-  email:
-  - kimmobrunfeldt+chokidar@gmail.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Chokidar CLI
 
-[![Build Status](https://travis-ci.org/kimmobrunfeldt/chokidar-cli.svg?branch=master)](https://travis-ci.org/kimmobrunfeldt/chokidar-cli)
+[![Build Status](https://github.com/kimmobrunfeldt/chokidar-cli/workflows/Tests/badge.svg)](https://github.com/kimmobrunfeldt/chokidar-cli/actions?workflow=Tests)
 
 Fast cross-platform command line utility to watch file system changes.
 


### PR DESCRIPTION
Issues:

1. We need Actions enabled for the repo 
2. chokidar-cli requires the `$SHELL` env var which is not set on Actions CI. We could set it ourselves but I think this could be more clever. Not sure how tests pass right now on Travis; do they set the `$SHELL` variable?
3. Windows tests fail either with git bash or native cmd
4. tests don't seem to exit when a failure happens, i.e. there's an unhandled Promise rejection somewhere in tests

Preview of the failed test: <https://github.com/XhmikosR/chokidar-cli/runs/274861409>

Fixes #83 