### PR TITLE
Windows fixes and removal of `$SHELL`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,3 @@ jobs:
       - name: Run tests
         run: npm test
         shell: bash
-        env:
-          SHELL: "/bin/bash"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ test-fixtures
 coverage
 *.bak
 *.log
+test/dir/change

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "scripts": {
     "lint": "eslint --report-unused-disable-directives --ignore-path .gitignore .",
-    "mocha": "mocha",
+    "mocha": "mocha --exit --timeout 5000",
     "test": "npm run lint && npm run mocha"
   },
   "engines": {

--- a/test/test-all.js
+++ b/test/test-all.js
@@ -10,7 +10,7 @@ const assert = require('assert');
 const {run} = require('../utils');
 
 // If true, output of commands are shown
-const DEBUG_TESTS = false;
+const DEBUG_TESTS = true;
 
 // Time to wait for different tasks
 const TIMEOUT_WATCH_READY = 1000;

--- a/utils.js
+++ b/utils.js
@@ -2,20 +2,9 @@
 
 const {spawn} = require('child_process');
 
-// Try to resolve path to shell.
-// We assume that Windows provides COMSPEC env variable
-// and other platforms provide SHELL env variable
-const SHELL_PATH = process.env.SHELL || process.env.COMSPEC;
-const EXECUTE_OPTION = process.env.COMSPEC !== undefined && process.env.SHELL === undefined ? '/c' : '-c';
-
 // XXX: Wrapping tos to a promise is a bit wrong abstraction. Maybe RX suits
 // better?
 function run(cmd, opts) {
-    if (!SHELL_PATH) {
-        // If we cannot resolve shell, better to just crash
-        throw new Error('$SHELL environment variable is not set.');
-    }
-
     opts = {
         pipe: true,
         cwd: undefined,
@@ -31,8 +20,9 @@ function run(cmd, opts) {
         let child;
 
         try {
-            child = spawn(SHELL_PATH, [EXECUTE_OPTION, cmd], {
+            child = spawn(cmd, {
                 cwd: opts.cwd,
+                shell: true,
                 stdio: opts.pipe ? 'inherit' : null
             });
         } catch (error) {


### PR DESCRIPTION
This is my WIP branch. It does work but there are a few things I'm not sure about

1. running tests leaves open handles behind; you can see this on GitHub Actions in the cleaning up step:
    > Cleaning up orphan processes
    > Terminate orphan process: pid (1224) (node)
    > Terminate orphan process: pid (6808) (node)
2. I switched to `shell: true`; this might have other implications we need to test
3. I had to set `DEBUG_TESTS = true` otherwise tests didn't pass on Windows; would be nice to find the root cause
4. We need to verify if we need #88 or not

Fixes #84, fixes #62, fixes #61